### PR TITLE
Properly await for terminated processes

### DIFF
--- a/sv-sanitizers.py
+++ b/sv-sanitizers.py
@@ -129,6 +129,7 @@ async def run_one(args, executable):
             else:
                 return None
         finally:
+            await process.wait()
             processes.remove(process)
 
 async def run_worker(args, executable):
@@ -147,6 +148,7 @@ async def run(args, executable):
         process.kill()
     for task in pending:
         task.cancel()
+    await asyncio.wait(tasks)
     return done.pop().result()
 
 def generate_witness(args, result):

--- a/sv-sanitizers.py
+++ b/sv-sanitizers.py
@@ -145,7 +145,10 @@ async def run(args, executable):
     global stop
     stop = True
     for process in processes:
-        process.kill()
+        try:
+            process.kill()
+        except ProcessLookupError as ex:
+            pass
     for task in pending:
         task.cancel()
     await asyncio.wait(tasks)


### PR DESCRIPTION
Upon running current script version on goblint VM, I have frequently encountered the following exception when any of sanitizer subprocesses finds a data race:
```
Exception ignored in: <function BaseSubprocessTransport.__del__ at 0x7ccc248d3c40>                                                                                                                                                                                                                                                                                                          
Traceback (most recent call last):                                                                                                                                                                                                                                                                                                                                                          
  File "/usr/lib/python3.12/asyncio/base_subprocess.py", line 126, in __del__                                                                                                                                                                                                                                                                                                               
    self.close()                                                                                                                                                                                                                                                                                                                                                                            
  File "/usr/lib/python3.12/asyncio/base_subprocess.py", line 104, in close                                                                                                                                                                                                                                                                                                                 
    proto.pipe.close()                                                                                                                                                                                                                                                                                                                                                                      
  File "/usr/lib/python3.12/asyncio/unix_events.py", line 568, in close                                                                                                                                                                                                                                                                                                                     
    self._close(None)                                                                                                                                                                                                                                                                                                                                                                       
  File "/usr/lib/python3.12/asyncio/unix_events.py", line 592, in _close                                                                                                                                                                                                                                                                                                                    
    self._loop.call_soon(self._call_connection_lost, exc)                                                                                                                                                                                                                                                                                                                                   
  File "/usr/lib/python3.12/asyncio/base_events.py", line 795, in call_soon                                                                                                                                                                                                                                                                                                                 
    self._check_closed()                                                                                                                                                                                                                                                                                                                                                                    
  File "/usr/lib/python3.12/asyncio/base_events.py", line 541, in _check_closed                                                                                                                                                                                                                                                                                                             
    raise RuntimeError('Event loop is closed')                                                                                                                                                
RuntimeError: Event loop is closed
```

The reason seems to be that terminated processes are not awaited and thus the respective subprocess transport might still be alive after the event loop has been closed. 